### PR TITLE
Fixed driver setting for Amazon Redshift

### DIFF
--- a/app.R
+++ b/app.R
@@ -1150,6 +1150,9 @@ if (!interactive()) sink(stderr(), type = "output")
     host <- input$sqlhost
     dbname <- input$sqldb
     driver <- tolower(input$driver_picker)
+    if (driver == "amazon redshift") {
+      driver <- "redshift"
+    }
     port <- input$sqlport
     
     # require dbname check


### PR DESCRIPTION
At login the input value "Amazon Redshift" was not being changed to "redshift" and that made the connection test, and initial database checks fail